### PR TITLE
added snap/snapcraft support

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,27 @@
+name: amass-simosx
+version: '1.0.0'
+summary: Subdomain enumeration
+description: |
+  The amass tool searches Internet data sources, performs brute-force 
+  subdomain enumeration, searches web archives, and uses machine learning
+  to generate additional subdomain name guesses. DNS name resolution
+  is performed across many public servers so the authoritative server
+  will see the traffic coming from different locations.
+
+grade: stable
+confinement: strict
+
+apps:
+  amass:
+    command: amass
+    plugs:
+      - home
+      - network
+      - removable-media
+
+parts:
+  amass:
+    # source: https://github.com/caffix/amass.git
+    source: ../
+    source-tag: 1.0.0
+    plugin: go


### PR DESCRIPTION
Snaps are [installation packages that run in Ubuntu and other Linux distributions](https://snapcraft.io/).
I added here the configuration file to package "amass" using the "snapcraft" tool.
Then, you can upload the package to the snap package repository so that anyone can install from there. 

I have done this for a package name "amass-simosx" (the name "amass" is still available, and if you are OK with these, you can register it and upload yourself there). Here is how it looks:

# How to use (can try this now)
Search for the package name
```
$ snap find amass
Name          Version  Developer  Notes  Summary
amass-simosx  1.0.0    simosx     -      Subdomain enumeration

```
Install the package
```
$ sudo snap install amass-simosx
amass-simosx 1.0.0 from 'simosx' installed

```
Run `amass`. When you register the package name `amass`, the executable will be just `amass`.
```
$ amass-simosx.amass
...
```

# How to add your official amass snap to the Store

1. Install the tool `snapcraft`. See https://snapcraft.io/
2. In the `amass/` source directory, run `snapcraft`. The tool will find the instructions in snap/snapcraft.yaml, compile, build and package into a *.snap installation file.
3. Run 'snapcraft login' to login to the Store. If you do not have an account, create one at https://login.ubuntu.com/
4. Register the name 'amass' with:  snapcraft register amass
5. Upload the generated .snap file (step 2) to the Store, with `snapcraft push amass_1.0.0_amd64.snap`
6. Release the package to the Store with: `snapcraft release amass 1 stable`

I am OK to unrelease the `amass-simosx` once you release the official package.