### PR TITLE
README: Fix arg typo: '-noalts' -> '-no-alts'

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ $ amass -blf data/blacklist.txt -d example.com
 
 The amass feature that performs alterations on discovered names and attempt resolution can be disabled:
 ```
-$ amass -noalts -d example.com
+$ amass -no-alts -d example.com
 ```
 
 


### PR DESCRIPTION
Please note that "-no-alts" is slightly inconsistent as all other feature-disabling flags to not include a dash.